### PR TITLE
Adding python version 3.12

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -14,7 +14,7 @@ build:
     - gdptools = gdptools.__main__:main
   noarch: python
   script: {{ PYTHON }} -m pip install . -vv
-  number: 0
+  number: 1
 
 requirements:
   host:
@@ -32,7 +32,7 @@ requirements:
     - tqdm >=4.66.2,<5.0.0
     - statsmodels >=0.14.0,<0.15.0
     - dask-core >=2024.7.1,<2025.0.0
-    # - python >=3.9,<3.12
+    - python >=3.9,<3.13
     - fastparquet >=2024.2.0
     - pyarrow <17.0.0
     - dask-geopandas 0.4.1

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -18,7 +18,7 @@ build:
 
 requirements:
   host:
-    - python >=3.9,<3.13
+    - python >=3.9,<=3.12
     - pip
     - poetry-core >=1.0.0
   run:
@@ -32,7 +32,7 @@ requirements:
     - tqdm >=4.66.2,<5.0.0
     - statsmodels >=0.14.0,<0.15.0
     - dask-core >=2024.7.1,<2025.0.0
-    - python >=3.9,<3.13
+    - python >=3.9,<=3.12
     - fastparquet >=2024.2.0
     - pyarrow <17.0.0
     - dask-geopandas 0.4.1

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -18,7 +18,7 @@ build:
 
 requirements:
   host:
-    - python >=3.9,<3.12
+    - python >=3.9,<3.13
     - pip
     - poetry-core >=1.0.0
   run:
@@ -32,7 +32,7 @@ requirements:
     - tqdm >=4.66.2,<5.0.0
     - statsmodels >=0.14.0,<0.15.0
     - dask-core >=2024.7.1,<2025.0.0
-    - python >=3.9,<3.12
+    # - python >=3.9,<3.12
     - fastparquet >=2024.2.0
     - pyarrow <17.0.0
     - dask-geopandas 0.4.1


### PR DESCRIPTION
Quite simple edit. Increased the python limits to include 3.12. @ocefpaf, I work with @rmcd-mscb on gdptools however, he is out this week. This is the first time I've made a merge request for this repo, so let me know if there are other edits that I need to make in order to bump up the python version to include 3.12. Thanks!