### PR TITLE
Remove upper bounds

### DIFF
--- a/.ci_support/linux_64_.yaml
+++ b/.ci_support/linux_64_.yaml
@@ -5,4 +5,4 @@ channel_targets:
 docker_image:
 - quay.io/condaforge/linux-anvil-x86_64:alma9
 python_min:
-- '3.10'
+- '3.11'

--- a/recipe/pyarrow_unpin.patch
+++ b/recipe/pyarrow_unpin.patch
@@ -1,6 +1,6 @@
---- gdptools-0.3.3.orig/pyproject.toml	2020-02-01 21:00:00.000000000 -0300
-+++ gdptools-0.3.3/pyproject.toml	2026-01-02 12:00:00.000000000 -0300
-@@ -28,14 +28,14 @@
+--- a/pyproject.toml
++++ b/pyproject.toml
+@@ -28,14 +28,14 @@ dependencies = [
      "shapely>=2.0",
      "pyproj>=3.3.0",
 -    "xarray>=2024.7.0,<2025.0.0",

--- a/recipe/pyarrow_unpin.patch
+++ b/recipe/pyarrow_unpin.patch
@@ -1,6 +1,7 @@
 --- a/pyproject.toml
 +++ b/pyproject.toml
-@@ -28,14 +28,14 @@ dependencies = [
+@@ -30,17 +30,17 @@
+     "geopandas>=0.13.0",
      "shapely>=2.0",
      "pyproj>=3.3.0",
 -    "xarray>=2024.7.0,<2025.0.0",
@@ -28,3 +29,4 @@
      "s3fs>=2025.2.0",
      "click>=8.1,<9",
      "urllib3>=2.6.0",  # CVE-2025-66418, CVE-2025-66471
+     "exactextract>=0.3.0",

--- a/recipe/pyarrow_unpin.patch
+++ b/recipe/pyarrow_unpin.patch
@@ -1,10 +1,29 @@
---- gdptools-0.3.2.orig/pyproject.toml	2020-02-01 21:00:00.000000000 -0300
-+++ gdptools-0.3.2/pyproject.toml	2025-12-31 12:19:26.966892426 -0300
-@@ -44,7 +44,7 @@
-     "statsmodels>=0.14,<1.0",
+--- gdptools-0.3.3.orig/pyproject.toml	2020-02-01 21:00:00.000000000 -0300
++++ gdptools-0.3.3/pyproject.toml	2026-01-02 12:00:00.000000000 -0300
+@@ -28,14 +28,14 @@
+     "shapely>=2.0",
+     "pyproj>=3.3.0",
+-    "xarray>=2024.7.0,<2025.0.0",
++    "xarray>=2024.7.0",
+     "netcdf4>=1.5.8",
+     "zarr>=2.12.0",
+-    "rasterio>=1.2.9,<1.5.0",
++    "rasterio>=1.2.9",
+     "bottleneck>=1.3.3",
+     "dask-geopandas>0.4.1",
+     "dask>2024.8.0",
+     "joblib>=1.4.0",
+-    "rioxarray>=0.15,<0.21",
++    "rioxarray>=0.15",
+     "pydantic>=2",
+-    "pystac>=1.10,<2.0",
+-    "statsmodels>=0.14,<1.0",
++    "pystac>=1.10",
++    "statsmodels>=0.14",
      "tqdm>=4.66.2",
-     "fastparquet>=2024.2,<=2024.5",
+-    "fastparquet>=2024.2,<=2024.5",
 -    "pyarrow>=10.0.0,<18.0.0",
++    "fastparquet>=2024.2",
 +    "pyarrow>=10.0.0",
      "s3fs>=2025.2.0",
      "click>=8.1,<9",

--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -32,7 +32,7 @@ requirements:
     - click >=8.1,<9
     - python >=${{ python_min }}
     - bottleneck >=1.3.3
-    - dask-core >2024.8.0
+    - dask >2024.8.0
     - dask-geopandas >0.4.1
     - fastparquet >=2024.2
     - geopandas >=0.13.0

--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -42,7 +42,7 @@ requirements:
     - pandas >=2.0.0
     - pyarrow >=10.0.0
     - pydantic >=2
-    - pyproj >=3.3.0
+    - pyproj >=3.7.2
     - pystac >=1.10
     - rasterio >=1.2.9
     - rioxarray >=0.15

--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -34,23 +34,23 @@ requirements:
     - bottleneck >=1.3.3
     - dask-core >2024.8.0
     - dask-geopandas >0.4.1
-    - fastparquet >=2024.2,<=2024.5
+    - fastparquet >=2024.2
     - geopandas >=0.13.0
     - joblib >=1.4.0
     - netcdf4 >=1.5.8
     - numpy >2.0
     - pandas >=2.0.0
-    - pyarrow >=10.0.0,<18.0.0
+    - pyarrow >=10.0.0
     - pydantic >=2
     - pyproj >=3.3.0
-    - pystac >=1.10,<2.0
-    - rasterio >=1.2.9,<1.5.0
-    - rioxarray >=0.15,<0.21
+    - pystac >=1.10
+    - rasterio >=1.2.9
+    - rioxarray >=0.15
     - s3fs >=2025.2.0
     - shapely >=2.0
-    - statsmodels >=0.14,<1.0
+    - statsmodels >=0.14
     - tqdm >=4.66.2
-    - xarray >=2024.7.0,<2025.0.0
+    - xarray >=2024.7.0
     - zarr >=2.12.0
     - urllib3 >=2.6.0
     - exactextract >=0.3.0

--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -2,7 +2,7 @@
 schema_version: 1
 
 context:
-  version: 0.3.2
+  version: 0.3.3
   python_max_check: '3.13'
 
 package:
@@ -11,7 +11,7 @@ package:
 
 source:
   url: https://pypi.org/packages/source/g/gdptools/gdptools-${{ version }}.tar.gz
-  sha256: 710196ded476b2417fd2dc046252e7ab6c6950acab4c27bec9d94677e47af70d
+  sha256: ca7862e31cda8c02b1c82928f0423fb74c5cd05e8c87ccfdcc05c222943cd67f
   patches:
     - pyarrow_unpin.patch
 
@@ -33,8 +33,6 @@ requirements:
     - python >=${{ python_min }}
     - bottleneck >=1.3.3
     - dask-core >2024.8.0
-    # dask-distributed
-    - distributed
     - dask-geopandas >0.4.1
     - fastparquet >=2024.2,<=2024.5
     - geopandas >=0.13.0
@@ -42,7 +40,7 @@ requirements:
     - netcdf4 >=1.5.8
     - numpy >2.0
     - pandas >=2.0.0
-    - pyarrow >=10.0.0
+    - pyarrow >=10.0.0,<18.0.0
     - pydantic >=2
     - pyproj >=3.3.0
     - pystac >=1.10,<2.0
@@ -55,6 +53,7 @@ requirements:
     - xarray >=2024.7.0,<2025.0.0
     - zarr >=2.12.0
     - urllib3 >=2.6.0
+    - exactextract >=0.3.0
 tests:
   - python:
       imports:


### PR DESCRIPTION
This PR builds on #62 (v0.3.3 update) by removing upper bounds from dependencies to allow more flexibility with newer package versions.

### Changes:
- Remove upper bounds from: `pyarrow`, `pystac`, `rasterio`, `rioxarray`, `statsmodels`, `xarray`, `fastparquet`
- Keep `click <9` constraint for compatibility
- Update patch file to remove upper bounds from source `pyproject.toml`

Closes #62

---

@conda-forge-admin, please rerender